### PR TITLE
Attempt to replicate dynamic field in web-form for prayer/alms requests

### DIFF
--- a/church/church_finances/web_form/alms_request/alms_request.js
+++ b/church/church_finances/web_form/alms_request/alms_request.js
@@ -1,3 +1,111 @@
-frappe.ready(function() {
-	// bind events here
-})
+// Runs inside frappe.init_client_script() — fields are already rendered
+var recip_ctrl = frappe.web_form.fields_dict['recipient'];
+var type_ctrl = frappe.web_form.fields_dict['recipient_type'];
+
+if (recip_ctrl && type_ctrl) {
+	var $input = recip_ctrl.$input;
+	var $wrap = recip_ctrl.$wrapper;
+	var real_name = frappe.web_form.doc && frappe.web_form.doc.recipient || '';
+
+	// Override get_value so the form submits the document name, not the display label
+	var original_get_value = recip_ctrl.get_value.bind(recip_ctrl);
+	recip_ctrl.get_value = function() {
+		return real_name || original_get_value();
+	};
+
+	// Build custom dropdown
+	var $dd = $('<ul>').css({
+		position: 'absolute',
+		background: '#fff',
+		border: '1px solid #d1d8dd',
+		borderRadius: '0 0 4px 4px',
+		boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+		listStyle: 'none',
+		padding: 0,
+		margin: 0,
+		maxHeight: '180px',
+		overflowY: 'auto',
+		zIndex: 9999,
+		display: 'none',
+		left: 0,
+		right: 0
+	});
+	$wrap.css('position', 'relative').append($dd);
+
+	var timer;
+
+	function search(term) {
+		var doctype = type_ctrl.get_value();
+		if (!doctype) { $dd.empty().hide(); return; }
+
+		clearTimeout(timer);
+		timer = setTimeout(function() {
+			frappe.call({
+				method: 'church.church_website.api.search_church_recipient',
+				args: { doctype: doctype, txt: term || '' },
+				callback: function(r) {
+					$dd.empty().hide();
+					var results = r.message || [];
+					results.forEach(function(d) {
+						$('<li>').text(d.label)
+							.css({ padding: '6px 12px', cursor: 'pointer' })
+							.hover(
+								function() { $(this).css('background', '#f4f5f7'); },
+								function() { $(this).css('background', '#fff'); }
+							)
+							.on('mousedown', function(e) {
+								e.preventDefault();
+								real_name = d.name;
+								$input.val(d.label);
+								$dd.hide();
+							})
+							.appendTo($dd);
+					});
+					if (results.length) $dd.show();
+				}
+			});
+		}, 250);
+	}
+
+	// When user types, clear the stored name so search uses their input
+	$input.on('input', function() { real_name = ''; search($(this).val()); });
+	$input.on('focus', function() { search($(this).val()); });
+	$input.on('blur', function() { setTimeout(function() { $dd.hide(); }, 200); });
+
+	frappe.web_form.on('recipient_type', function() {
+		real_name = '';
+		$input.val('');
+		$dd.empty().hide();
+	});
+
+	// Resolve label for existing recipient value
+	if (real_name && frappe.web_form.doc.recipient_type) {
+		frappe.call({
+			method: 'church.church_website.api.search_church_recipient',
+			args: { doctype: frappe.web_form.doc.recipient_type, txt: '' },
+			callback: function(r) {
+				var results = r.message || [];
+				for (var i = 0; i < results.length; i++) {
+					if (results[i].name === real_name) {
+						$input.val(results[i].label);
+						break;
+					}
+				}
+			}
+		});
+	}
+}
+
+// Auto-populate church from the logged-in user's church
+var church_ctrl = frappe.web_form.fields_dict['church'];
+if (church_ctrl && !frappe.web_form.doc.name) {
+	frappe.call({
+		method: 'frappe.client.get_value',
+		args: { doctype: 'User', filters: { name: frappe.session.user }, fieldname: 'church' },
+		callback: function(r) {
+			if (r.message && r.message.church) {
+				church_ctrl.set_value(r.message.church);
+			}
+		}
+	});
+}

--- a/church/church_finances/web_form/alms_request/alms_request.json
+++ b/church/church_finances/web_form/alms_request/alms_request.json
@@ -46,7 +46,7 @@
  "list_title": "Your Alms Requests",
  "login_required": 1,
  "max_attachment_size": 0,
- "modified": "2026-03-09 19:31:10.125508",
+ "modified": "2026-03-15 05:23:34.923651",
  "modified_by": "Administrator",
  "module": "Church Finances",
  "name": "alms-request",
@@ -113,7 +113,7 @@
    "show_in_filter": 0
   },
   {
-   "allow_read_on_all_link_options": 0,
+   "allow_read_on_all_link_options": 1,
    "description": "The person making the request.",
    "fieldname": "requestor",
    "fieldtype": "Link",
@@ -128,18 +128,32 @@
    "show_in_filter": 0
   },
   {
-   "allow_read_on_all_link_options": 0,
+   "description": "The type of entity that would be receiving the alms.",
+   "fieldname": "recipient_type",
+   "fieldtype": "Select",
+   "hidden": 0,
+   "label": "Recipient Type",
+   "max_length": 0,
+   "max_value": 0,
+   "options": "Person\nFamily\nMissionary",
+   "precision": "",
+   "read_only": 0,
+   "reqd": 1,
+   "show_in_filter": 0,
+   "default": "Person"
+  },
+  {
    "fieldname": "recipient",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "hidden": 0,
    "label": "Recipient",
    "max_length": 0,
    "max_value": 0,
-   "options": "Person",
    "precision": "",
    "read_only": 0,
    "reqd": 1,
-   "show_in_filter": 0
+   "show_in_filter": 0,
+   "description": "The entity that would be receiving the alms."
   },
   {
    "allow_read_on_all_link_options": 0,
@@ -166,5 +180,6 @@
    "reqd": 1,
    "show_in_filter": 0
   }
- ]
+ ],
+ "client_script": "// Runs inside frappe.init_client_script() — fields are already rendered\nvar recip_ctrl = frappe.web_form.fields_dict['recipient'];\nvar type_ctrl = frappe.web_form.fields_dict['recipient_type'];\n\nif (recip_ctrl && type_ctrl) {\n\tvar $input = recip_ctrl.$input;\n\tvar $wrap = recip_ctrl.$wrapper;\n\tvar real_name = frappe.web_form.doc && frappe.web_form.doc.recipient || '';\n\n\t// Override get_value so the form submits the document name, not the display label\n\tvar original_get_value = recip_ctrl.get_value.bind(recip_ctrl);\n\trecip_ctrl.get_value = function() {\n\t\treturn real_name || original_get_value();\n\t};\n\n\t// Build custom dropdown\n\tvar $dd = $('<ul>').css({\n\t\tposition: 'absolute',\n\t\tbackground: '#fff',\n\t\tborder: '1px solid #d1d8dd',\n\t\tborderRadius: '0 0 4px 4px',\n\t\tboxShadow: '0 4px 8px rgba(0,0,0,0.1)',\n\t\tlistStyle: 'none',\n\t\tpadding: 0,\n\t\tmargin: 0,\n\t\tmaxHeight: '180px',\n\t\toverflowY: 'auto',\n\t\tzIndex: 9999,\n\t\tdisplay: 'none',\n\t\tleft: 0,\n\t\tright: 0\n\t});\n\t$wrap.css('position', 'relative').append($dd);\n\n\tvar timer;\n\n\tfunction search(term) {\n\t\tvar doctype = type_ctrl.get_value();\n\t\tif (!doctype) { $dd.empty().hide(); return; }\n\n\t\tclearTimeout(timer);\n\t\ttimer = setTimeout(function() {\n\t\t\tfrappe.call({\n\t\t\t\tmethod: 'church.church_website.api.search_church_recipient',\n\t\t\t\targs: { doctype: doctype, txt: term || '' },\n\t\t\t\tcallback: function(r) {\n\t\t\t\t\t$dd.empty().hide();\n\t\t\t\t\tvar results = r.message || [];\n\t\t\t\t\tresults.forEach(function(d) {\n\t\t\t\t\t\t$('<li>').text(d.label)\n\t\t\t\t\t\t\t.css({ padding: '6px 12px', cursor: 'pointer' })\n\t\t\t\t\t\t\t.hover(\n\t\t\t\t\t\t\t\tfunction() { $(this).css('background', '#f4f5f7'); },\n\t\t\t\t\t\t\t\tfunction() { $(this).css('background', '#fff'); }\n\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t.on('mousedown', function(e) {\n\t\t\t\t\t\t\t\te.preventDefault();\n\t\t\t\t\t\t\t\treal_name = d.name;\n\t\t\t\t\t\t\t\t$input.val(d.label);\n\t\t\t\t\t\t\t\t$dd.hide();\n\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t.appendTo($dd);\n\t\t\t\t\t});\n\t\t\t\t\tif (results.length) $dd.show();\n\t\t\t\t}\n\t\t\t});\n\t\t}, 250);\n\t}\n\n\t// When user types, clear the stored name so search uses their input\n\t$input.on('input', function() { real_name = ''; search($(this).val()); });\n\t$input.on('focus', function() { search($(this).val()); });\n\t$input.on('blur', function() { setTimeout(function() { $dd.hide(); }, 200); });\n\n\tfrappe.web_form.on('recipient_type', function() {\n\t\treal_name = '';\n\t\t$input.val('');\n\t\t$dd.empty().hide();\n\t});\n\n\t// Resolve label for existing recipient value\n\tif (real_name && frappe.web_form.doc.recipient_type) {\n\t\tfrappe.call({\n\t\t\tmethod: 'church.church_website.api.search_church_recipient',\n\t\t\targs: { doctype: frappe.web_form.doc.recipient_type, txt: '' },\n\t\t\tcallback: function(r) {\n\t\t\t\tvar results = r.message || [];\n\t\t\t\tfor (var i = 0; i < results.length; i++) {\n\t\t\t\t\tif (results[i].name === real_name) {\n\t\t\t\t\t\t$input.val(results[i].label);\n\t\t\t\t\t\tbreak;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t});\n\t}\n}\n\n// Auto-populate church from the logged-in user's church\nvar church_ctrl = frappe.web_form.fields_dict['church'];\nif (church_ctrl && !frappe.web_form.doc.name) {\n\tfrappe.call({\n\t\tmethod: 'frappe.client.get_value',\n\t\targs: { doctype: 'User', filters: { name: frappe.session.user }, fieldname: 'church' },\n\t\tcallback: function(r) {\n\t\t\tif (r.message && r.message.church) {\n\t\t\t\tchurch_ctrl.set_value(r.message.church);\n\t\t\t}\n\t\t}\n\t});\n}\n"
 }

--- a/church/church_prayers/web_form/prayer_request/prayer_request.js
+++ b/church/church_prayers/web_form/prayer_request/prayer_request.js
@@ -1,3 +1,127 @@
-frappe.ready(function() {
-	// bind events here
-})
+// Runs inside frappe.init_client_script() — fields are already rendered
+var recip_ctrl = frappe.web_form.fields_dict['recipient'];
+var type_ctrl = frappe.web_form.fields_dict['recipient_type'];
+
+if (recip_ctrl && type_ctrl) {
+	// Populate recipient_type with church app doctypes from the server
+	frappe.call({
+		method: 'church.church_website.api.get_church_doctypes',
+		args: {},
+		callback: function(r) {
+			var $select = type_ctrl.$input;
+			$select.empty().append($('<option value="">').text(''));
+			(r.message || []).forEach(function(d) {
+				$select.append($('<option>').val(d.name).text(d.name));
+			});
+			// Restore value if editing an existing record
+			var existing = frappe.web_form.doc && frappe.web_form.doc.recipient_type;
+			if (existing) $select.val(existing);
+		}
+	});
+
+	var $input = recip_ctrl.$input;
+	var $wrap = recip_ctrl.$wrapper;
+	var real_name = frappe.web_form.doc && frappe.web_form.doc.recipient || '';
+
+	// Override get_value so the form submits the document name, not the display label
+	var original_get_value = recip_ctrl.get_value.bind(recip_ctrl);
+	recip_ctrl.get_value = function() {
+		return real_name || original_get_value();
+	};
+
+	// Build custom dropdown for recipient
+	var $dd = $('<ul>').css({
+		position: 'absolute',
+		background: '#fff',
+		border: '1px solid #d1d8dd',
+		borderRadius: '0 0 4px 4px',
+		boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+		listStyle: 'none',
+		padding: 0,
+		margin: 0,
+		maxHeight: '180px',
+		overflowY: 'auto',
+		zIndex: 9999,
+		display: 'none',
+		left: 0,
+		right: 0
+	});
+	$wrap.css('position', 'relative').append($dd);
+
+	var timer;
+
+	function search(term) {
+		var doctype = type_ctrl.get_value();
+		if (!doctype) { $dd.empty().hide(); return; }
+
+		clearTimeout(timer);
+		timer = setTimeout(function() {
+			frappe.call({
+				method: 'church.church_website.api.search_church_recipient',
+				args: { doctype: doctype, txt: term || '' },
+				callback: function(r) {
+					$dd.empty().hide();
+					var results = r.message || [];
+					results.forEach(function(d) {
+						$('<li>').text(d.label)
+							.css({ padding: '6px 12px', cursor: 'pointer' })
+							.hover(
+								function() { $(this).css('background', '#f4f5f7'); },
+								function() { $(this).css('background', '#fff'); }
+							)
+							.on('mousedown', function(e) {
+								e.preventDefault();
+								real_name = d.name;
+								$input.val(d.label);
+								$dd.hide();
+							})
+							.appendTo($dd);
+					});
+					if (results.length) $dd.show();
+				}
+			});
+		}, 250);
+	}
+
+	// When user types, clear the stored name so search uses their input
+	$input.on('input', function() { real_name = ''; search($(this).val()); });
+	$input.on('focus', function() { search($(this).val()); });
+	$input.on('blur', function() { setTimeout(function() { $dd.hide(); }, 200); });
+
+	frappe.web_form.on('recipient_type', function() {
+		real_name = '';
+		$input.val('');
+		$dd.empty().hide();
+	});
+
+	// Resolve label for existing recipient value
+	if (real_name && frappe.web_form.doc.recipient_type) {
+		frappe.call({
+			method: 'church.church_website.api.search_church_recipient',
+			args: { doctype: frappe.web_form.doc.recipient_type, txt: '' },
+			callback: function(r) {
+				var results = r.message || [];
+				for (var i = 0; i < results.length; i++) {
+					if (results[i].name === real_name) {
+						$input.val(results[i].label);
+						break;
+					}
+				}
+			}
+		});
+	}
+}
+
+// Auto-populate church from the logged-in user's church
+var church_ctrl = frappe.web_form.fields_dict['church'];
+if (church_ctrl && !frappe.web_form.doc.name) {
+	frappe.call({
+		method: 'frappe.client.get_value',
+		args: { doctype: 'User', filters: { name: frappe.session.user }, fieldname: 'church' },
+		callback: function(r) {
+			if (r.message && r.message.church) {
+				church_ctrl.set_value(r.message.church);
+			}
+		}
+	});
+}

--- a/church/church_prayers/web_form/prayer_request/prayer_request.json
+++ b/church/church_prayers/web_form/prayer_request/prayer_request.json
@@ -8,7 +8,7 @@
  "anonymous": 0,
  "apply_document_permissions": 1,
  "button_label": "Save",
- "client_script": "",
+ "client_script": "// Runs inside frappe.init_client_script() — fields are already rendered\nvar recip_ctrl = frappe.web_form.fields_dict['recipient'];\nvar type_ctrl = frappe.web_form.fields_dict['recipient_type'];\n\nif (recip_ctrl && type_ctrl) {\n\t// Populate recipient_type with church app doctypes from the server\n\tfrappe.call({\n\t\tmethod: 'church.church_website.api.get_church_doctypes',\n\t\targs: {},\n\t\tcallback: function(r) {\n\t\t\tvar $select = type_ctrl.$input;\n\t\t\t$select.empty().append($('<option value=\"\">').text(''));\n\t\t\t(r.message || []).forEach(function(d) {\n\t\t\t\t$select.append($('<option>').val(d.name).text(d.name));\n\t\t\t});\n\t\t\t// Restore value if editing an existing record\n\t\t\tvar existing = frappe.web_form.doc && frappe.web_form.doc.recipient_type;\n\t\t\tif (existing) $select.val(existing);\n\t\t}\n\t});\n\n\tvar $input = recip_ctrl.$input;\n\tvar $wrap = recip_ctrl.$wrapper;\n\tvar real_name = frappe.web_form.doc && frappe.web_form.doc.recipient || '';\n\n\t// Override get_value so the form submits the document name, not the display label\n\tvar original_get_value = recip_ctrl.get_value.bind(recip_ctrl);\n\trecip_ctrl.get_value = function() {\n\t\treturn real_name || original_get_value();\n\t};\n\n\t// Build custom dropdown for recipient\n\tvar $dd = $('<ul>').css({\n\t\tposition: 'absolute',\n\t\tbackground: '#fff',\n\t\tborder: '1px solid #d1d8dd',\n\t\tborderRadius: '0 0 4px 4px',\n\t\tboxShadow: '0 4px 8px rgba(0,0,0,0.1)',\n\t\tlistStyle: 'none',\n\t\tpadding: 0,\n\t\tmargin: 0,\n\t\tmaxHeight: '180px',\n\t\toverflowY: 'auto',\n\t\tzIndex: 9999,\n\t\tdisplay: 'none',\n\t\tleft: 0,\n\t\tright: 0\n\t});\n\t$wrap.css('position', 'relative').append($dd);\n\n\tvar timer;\n\n\tfunction search(term) {\n\t\tvar doctype = type_ctrl.get_value();\n\t\tif (!doctype) { $dd.empty().hide(); return; }\n\n\t\tclearTimeout(timer);\n\t\ttimer = setTimeout(function() {\n\t\t\tfrappe.call({\n\t\t\t\tmethod: 'church.church_website.api.search_church_recipient',\n\t\t\t\targs: { doctype: doctype, txt: term || '' },\n\t\t\t\tcallback: function(r) {\n\t\t\t\t\t$dd.empty().hide();\n\t\t\t\t\tvar results = r.message || [];\n\t\t\t\t\tresults.forEach(function(d) {\n\t\t\t\t\t\t$('<li>').text(d.label)\n\t\t\t\t\t\t\t.css({ padding: '6px 12px', cursor: 'pointer' })\n\t\t\t\t\t\t\t.hover(\n\t\t\t\t\t\t\t\tfunction() { $(this).css('background', '#f4f5f7'); },\n\t\t\t\t\t\t\t\tfunction() { $(this).css('background', '#fff'); }\n\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t.on('mousedown', function(e) {\n\t\t\t\t\t\t\t\te.preventDefault();\n\t\t\t\t\t\t\t\treal_name = d.name;\n\t\t\t\t\t\t\t\t$input.val(d.label);\n\t\t\t\t\t\t\t\t$dd.hide();\n\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t.appendTo($dd);\n\t\t\t\t\t});\n\t\t\t\t\tif (results.length) $dd.show();\n\t\t\t\t}\n\t\t\t});\n\t\t}, 250);\n\t}\n\n\t// When user types, clear the stored name so search uses their input\n\t$input.on('input', function() { real_name = ''; search($(this).val()); });\n\t$input.on('focus', function() { search($(this).val()); });\n\t$input.on('blur', function() { setTimeout(function() { $dd.hide(); }, 200); });\n\n\tfrappe.web_form.on('recipient_type', function() {\n\t\treal_name = '';\n\t\t$input.val('');\n\t\t$dd.empty().hide();\n\t});\n\n\t// Resolve label for existing recipient value\n\tif (real_name && frappe.web_form.doc.recipient_type) {\n\t\tfrappe.call({\n\t\t\tmethod: 'church.church_website.api.search_church_recipient',\n\t\t\targs: { doctype: frappe.web_form.doc.recipient_type, txt: '' },\n\t\t\tcallback: function(r) {\n\t\t\t\tvar results = r.message || [];\n\t\t\t\tfor (var i = 0; i < results.length; i++) {\n\t\t\t\t\tif (results[i].name === real_name) {\n\t\t\t\t\t\t$input.val(results[i].label);\n\t\t\t\t\t\tbreak;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t});\n\t}\n}\n\n// Auto-populate church from the logged-in user's church\nvar church_ctrl = frappe.web_form.fields_dict['church'];\nif (church_ctrl && !frappe.web_form.doc.name) {\n\tfrappe.call({\n\t\tmethod: 'frappe.client.get_value',\n\t\targs: { doctype: 'User', filters: { name: frappe.session.user }, fieldname: 'church' },\n\t\tcallback: function(r) {\n\t\t\tif (r.message && r.message.church) {\n\t\t\t\tchurch_ctrl.set_value(r.message.church);\n\t\t\t}\n\t\t}\n\t});\n}\n",
  "condition_json": "[]",
  "creation": "2025-09-13 22:28:01.939717",
  "doc_type": "Prayer Request",
@@ -34,9 +34,9 @@
    "label": ""
   },
   {
-   "fieldname": "related_person",
-   "fieldtype": "Link",
-   "label": ""
+   "fieldname": "recipient",
+   "fieldtype": "Data",
+   "label": "Recipient"
   },
   {
    "fieldname": "section_break_usaz",
@@ -57,7 +57,7 @@
  "list_title": "Your Prayer Requests",
  "login_required": 1,
  "max_attachment_size": 0,
- "modified": "2026-03-09 19:31:23.329652",
+ "modified": "2026-03-15 05:23:34.922923",
  "modified_by": "Administrator",
  "module": "Church Prayers",
  "name": "prayer-request",
@@ -114,6 +114,34 @@
    "show_in_filter": 0
   },
   {
+   "description": "The type of entity you are requesting prayer for.",
+   "fieldname": "recipient_type",
+   "fieldtype": "Select",
+   "hidden": 0,
+   "label": "Recipient Type",
+   "max_length": 0,
+   "max_value": 0,
+   "options": "",
+   "precision": "",
+   "read_only": 0,
+   "reqd": 0,
+   "show_in_filter": 0
+  },
+  {
+   "default": "",
+   "description": "The person or entity you are requesting prayer for.",
+   "fieldname": "recipient",
+   "fieldtype": "Data",
+   "hidden": 0,
+   "label": "Recipient",
+   "max_length": 0,
+   "max_value": 0,
+   "precision": "",
+   "read_only": 0,
+   "reqd": 0,
+   "show_in_filter": 0
+  },
+  {
    "allow_read_on_all_link_options": 0,
    "fieldname": "column_break_ynvf",
    "fieldtype": "Column Break",
@@ -127,7 +155,7 @@
    "show_in_filter": 0
   },
   {
-   "allow_read_on_all_link_options": 0,
+   "allow_read_on_all_link_options": 1,
    "default": "",
    "description": "The person making the request.",
    "fieldname": "requestor",

--- a/church/church_website/api.py
+++ b/church/church_website/api.py
@@ -1,0 +1,46 @@
+import frappe
+
+
+@frappe.whitelist(allow_guest=False)
+def get_church_doctypes():
+	"""Return non-child doctypes belonging to church app modules."""
+	return frappe.get_all(
+		"DocType",
+		filters=[["module", "like", "Church%"], ["istable", "=", 0]],
+		fields=["name"],
+		order_by="name asc",
+		ignore_permissions=True,
+	)
+
+
+@frappe.whitelist(allow_guest=False)
+def search_church_recipient(doctype, txt):
+	"""Search records of the given church doctype, returning name and display label."""
+	allowed = frappe.get_all(
+		"DocType",
+		filters=[["module", "like", "Church%"], ["istable", "=", 0]],
+		fields=["name"],
+		ignore_permissions=True,
+		pluck="name",
+	)
+	if doctype not in allowed:
+		frappe.throw("Not allowed", frappe.PermissionError)
+
+	meta = frappe.get_meta(doctype)
+	title_field = meta.title_field or None
+
+	results = frappe.get_all(
+		doctype,
+		filters=[["name", "like", f"%{txt}%"]] if txt else [],
+		or_filters=([[title_field, "like", f"%{txt}%"]] if txt and title_field and title_field != "name" else []),
+		fields=["name"] + ([title_field] if title_field and title_field != "name" else []),
+		order_by="name asc",
+		limit=20,
+		ignore_permissions=True,
+	)
+
+	out = []
+	for r in results:
+		label = (r.get(title_field) or r.name) if title_field and title_field != "name" else r.name
+		out.append({"name": r.name, "label": label})
+	return out


### PR DESCRIPTION
This is 'hacky', but it works. 

We create a new api.py to handle the logic of fetching documents of a selected type.
This allows the user to see the names of documents, but not the contents.